### PR TITLE
Add switch_name and switch_id variables

### DIFF
--- a/blueprints/automation/rohankapoorcom/inovelli-vzm31-sn-blue-series-switch.yaml
+++ b/blueprints/automation/rohankapoorcom/inovelli-vzm31-sn-blue-series-switch.yaml
@@ -170,7 +170,7 @@ actions:
   - variables:
       button_id: '{{ trigger.payload_json.action }}'
       switch_name: "{{ trigger.topic.split('/')[1] }}"
-      switch_id: >-
+      switch_device_id: >-
         {% set ns = namespace(found='') %}
         {% for id in device_id %}
           {% if device_attr(id, 'name') == switch_name %}
@@ -178,6 +178,8 @@ actions:
           {% endif %}
         {% endfor %}
         {{ ns.found }}
+      switch_entities: "{{ device_entities(switch_device_id) }}"
+      switch_light_entity_id: "{{ device_entities(switch_device_id) | select('match','^light\\.') | list | first }}"
   - choose:
       - conditions: '{{ button_id == "config_single" }}'
         sequence: !input 'config_button'

--- a/blueprints/automation/rohankapoorcom/inovelli-vzm31-sn-blue-series-switch.yaml
+++ b/blueprints/automation/rohankapoorcom/inovelli-vzm31-sn-blue-series-switch.yaml
@@ -169,6 +169,15 @@ conditions:
 actions:
   - variables:
       button_id: '{{ trigger.payload_json.action }}'
+      switch_name: "{{ trigger.topic.split('/')[1] }}"
+      switch_id: >-
+        {% set ns = namespace(found='') %}
+        {% for id in device_id %}
+          {% if device_attr(id, 'name') == switch_name %}
+            {% set ns.found = id %}
+          {% endif %}
+        {% endfor %}
+        {{ ns.found }}
   - choose:
       - conditions: '{{ button_id == "config_single" }}'
         sequence: !input 'config_button'

--- a/docs/blueprints/automation/inovelli-vzm31-sn-blue-series-switch-blueprint.md
+++ b/docs/blueprints/automation/inovelli-vzm31-sn-blue-series-switch-blueprint.md
@@ -41,7 +41,7 @@ This blueprint provides comprehensive automation for Inovelli VZM31-SN Blue Seri
 ## Variables
 - `switch_name`: Name of the switch that triggered the automation
 - `switch_device_id`: Device ID of the switch that triggered the automation
-- `switch_entities`: All entities associated with the swich that triggered the automation
+- `switch_entities`: All entities associated with the switch that triggered the automation
 - `switch_light_entity_id`: Entity ID of the switch light that triggered the automation
 
 ## Functionality

--- a/docs/blueprints/automation/inovelli-vzm31-sn-blue-series-switch-blueprint.md
+++ b/docs/blueprints/automation/inovelli-vzm31-sn-blue-series-switch-blueprint.md
@@ -38,6 +38,12 @@ This blueprint provides comprehensive automation for Inovelli VZM31-SN Blue Seri
 - `button_a5`: Action for Up/On button quintuple press
 - `button_b5`: Action for Down/Off button quintuple press
 
+## Variables
+- `switch_name`: Name of the switch that triggered the automation
+- `switch_device_id`: Device ID of the switch that triggered the automation
+- `switch_entities`: All entities associated with the swich that triggered the automation
+- `switch_light_entity_id`: Entity ID of the switch light that triggered the automation
+
 ## Functionality
 This blueprint creates an automation that:
 
@@ -46,6 +52,7 @@ This blueprint creates an automation that:
 3. **Handles button actions**: Processes single, double, triple, quadruple, quintuple, hold, and release events
 4. **Maps to actions**: Executes the appropriate action based on button and press type
 5. **Supports multiple devices**: Can handle multiple Inovelli VZM31-SN switches simultaneously
+6. **Adds variables for triggering device**: Instead of creating multiple automations per device, pass `switch_device_id` and/or `switch_light_entity_id` to your automation
 
 ## Usage Examples
 ```yaml
@@ -73,13 +80,13 @@ This blueprint creates an automation that:
       button_a_held:
         - service: light.turn_on
           target:
-            entity_id: light.living_room_ceiling
+            entity_id: "{{ switch_light_entity_id }}"
           data:
             brightness_pct: 100
       config_button:
-        - service: scene.turn_on
+        - action: light.toggle
           target:
-            entity_id: scene.living_room_normal
+            device_id: "{{ switch_device_id }}" 
 ```
 
 ## Dependencies


### PR DESCRIPTION
These are useful if you want to use the same automation on multiple devices while only running an action on the triggering device. 

This would probably be useful on the red switches as well, though I don't have any so I didn't include that.
