### PR TITLE
tablets: fix Fully Kiosk integration domain in restart automation

### DIFF
--- a/packages/tablets.yaml
+++ b/packages/tablets.yaml
@@ -17,7 +17,7 @@ automation:
         target:
           entity_id: |
             {{
-              expand(integration_entities('fullykiosk'))
+              expand(integration_entities('fully_kiosk'))
               | selectattr('entity_id', 'search', '_restart_browser')
               | map(attribute='entity_id')
               | list


### PR DESCRIPTION
This PR fixes the template in `packages/tablets.yaml` where the Fully Kiosk integration domain was misspelled as `fullykiosk`.

Change:
- Use `integration_entities('fully_kiosk')` so the entity selection resolves properly and the restart button presses execute.

Automation affected:
- `Restart Fully Kiosk Browsers` (`f126138c-bb79-4a9c-957a-a727ab53f95f`)

This ensures the daily tablet browser restarts run as expected.