### PR TITLE
fix: normalize numeric Z-Wave JS scene values for Inovelli VZW31-SN blueprint

### DIFF
--- a/blueprints/automation/rohankapoorcom/inovelli-vzw31-sn-red-series-switch.yaml
+++ b/blueprints/automation/rohankapoorcom/inovelli-vzw31-sn-red-series-switch.yaml
@@ -1,7 +1,7 @@
 # yamllint disable-line rule:line-length
 ---
 blueprint:
-  name: Inovelli Red Series VZW31-SN Red Series Switch (ZWave-JS) — fixed press normalization
+  name: Inovelli Red Series VZW31-SN Red Series Switch (ZWave-JS)
   description: >
     Works with both string and numeric Central Scene values from Z-Wave JS.
     Based on rohankapoorcom's blueprint with normalization for press events.


### PR DESCRIPTION
Some Z-Wave JS versions now report scene "value" as integers (e.g. 4) instead of string labels (e.g. "KeyPressed3x"). This caused scene-based actions not to trigger, especially on auxiliary switches. This patch adds normalization logic to map numeric values (0-6) to the expected string labels while preserving backward compatibility with string-based payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved button press detection and normalization to ensure consistent automation triggering across different button states.

* **Improvements**
  * Enhanced support for comprehensive button interactions including single and multiple presses, held states, and release events for more precise automation control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->