### PR TITLE
fix(dashboard): restore card layouts after HA 2026.4 auto-height changes

### DIFF
--- a/dashboards/components/panels/downstairs.yaml
+++ b/dashboards/components/panels/downstairs.yaml
@@ -147,8 +147,19 @@ cards:
     square: false
     view_layout:
       grid-area: left-bottom
-  - type: grid
-    cards:
+  - type: custom:mod-card
+    card_mod:
+      style:
+        hui-vertical-stack-card$: |
+          :host {
+            height: auto !important;
+          }
+          #root {
+            gap: 8px;
+          }
+    card:
+      type: vertical-stack
+      cards:
       - type: grid
         cards:
           - type: heading
@@ -224,10 +235,9 @@ cards:
             square: false
         columns: 1
         square: false
-    columns: 1
-    square: false
     view_layout:
       grid-area: right
+      align-self: start
 layout_type: custom:grid-layout
 layout:
   grid-template-columns: 1fr 1fr

--- a/dashboards/components/panels/home.yaml
+++ b/dashboards/components/panels/home.yaml
@@ -1,102 +1,123 @@
 type: custom:layout-card
 cards:
-  - type: custom:layout-card
-    layout_type: vertical
-    cards:
-      - type: grid
-        cards:
-          - type: custom:button-card
-            template: lock_button
-            entity: lock.front_door_lock
-            name: Front Door
-          - type: custom:button-card
-            template: lock_button
-            entity: lock.garage_door_lock
-            name: Garage Door
-          - type: custom:button-card
-            template: lock_button
-            entity: lock.side_door_lock
-            name: Side Door
-          - type: custom:button-card
-            template: lock_button
-            entity: cover.garage_door
-            name: Garage
-        columns: 4
-        square: false
-      - show_name: true
-        show_icon: true
-        show_state: true
-        type: glance
-        entities:
-          - entity: sensor.living_room_temperature
-            name: Living Rm
-          - entity: sensor.master_bedroom_temperature
-            name: Master Bed
-          - entity: sensor.office_temperature
-            name: Office
-          - entity: sensor.garage_temperature
-            name: Garage
-          - entity: sensor.server_rack_exhaust_fan_temperature_1
-            name: Server Rack
-        state_color: false
-      - type: alarm-panel
-        entity: alarm_control_panel.alarmo
-        name: Alarm
-        states:
-          - arm_home
-          - arm_away
+  - type: custom:mod-card
+    card_mod:
+      style:
+        hui-vertical-stack-card$: |
+          :host {
+            height: auto !important;
+          }
+          #root {
+            gap: 8px;
+          }
+    card:
+      type: vertical-stack
+      cards:
+        - type: grid
+          cards:
+            - type: custom:button-card
+              template: lock_button
+              entity: lock.front_door_lock
+              name: Front Door
+            - type: custom:button-card
+              template: lock_button
+              entity: lock.garage_door_lock
+              name: Garage Door
+            - type: custom:button-card
+              template: lock_button
+              entity: lock.side_door_lock
+              name: Side Door
+            - type: custom:button-card
+              template: lock_button
+              entity: cover.garage_door
+              name: Garage
+          columns: 4
+          square: false
+        - show_name: true
+          show_icon: true
+          show_state: true
+          type: glance
+          entities:
+            - entity: sensor.living_room_temperature
+              name: Living Rm
+            - entity: sensor.master_bedroom_temperature
+              name: Master Bed
+            - entity: sensor.office_temperature
+              name: Office
+            - entity: sensor.garage_temperature
+              name: Garage
+            - entity: sensor.server_rack_exhaust_fan_temperature_1
+              name: Server Rack
+          state_color: false
+        - type: alarm-panel
+          entity: alarm_control_panel.alarmo
+          name: Alarm
+          states:
+            - arm_home
+            - arm_away
     view_layout:
       grid-area: left
-  - type: custom:layout-card
-    layout_type: vertical
-    cards:
-      - type: custom:weather-card
-        current: true
-        details: true
-        entity: weather.local_weather
-        forecast: true
-        icons: /hacsfiles/weather-card/icons/
-        number_of_forecasts: '5'
-        card_mod:
-          style: |
-            .temp {
-              margin-top: -25px;
-            }
-
-      - type: custom:apexcharts-card
-        header:
-          show: true
-          title: U.S. Air Quality Index
-          show_states: true
-          colorize_states: true
-        series:
-          - entity: sensor.u_s_air_quality_index
-            name: Exterior
-          - entity: sensor.living_room_us_air_quality_index
-            name: Living Room
-            group_by:
-              func: avg
-              duration: 30min
-          - entity: sensor.master_bedroom_us_air_quality_index
-            name: Master Bedroom
-            group_by:
-              func: avg
-              duration: 30min
-          - entity: sensor.guest_room_us_air_quality_index
-            name: Guest Room
-            group_by:
-              func: avg
-              duration: 30min
-          - entity: sensor.downstairs_hallway_us_air_quality_index
-            name: Downstairs
-            group_by:
-              func: avg
-              duration: 30min
-        apex_config:
-          legend:
-            show: false
+      align-self: start
+  - type: custom:mod-card
+    card_mod:
+      style:
+        hui-vertical-stack-card$: |
+          :host {
+            height: auto !important;
+          }
+          #root {
+            gap: 8px;
+          }
+    card:
+      type: vertical-stack
+      cards:
+        - type: custom:weather-card
+          current: true
+          details: true
+          entity: weather.local_weather
+          forecast: true
+          icons: /hacsfiles/weather-card/icons/
+          number_of_forecasts: '5'
+          card_mod:
+            style: |
+              .temp {
+                margin-top: -25px;
+              }
+        - type: custom:apexcharts-card
+          header:
+            show: true
+            title: U.S. Air Quality Index
+            show_states: true
+            colorize_states: true
+          series:
+            - entity: sensor.u_s_air_quality_index
+              name: Exterior
+            - entity: sensor.living_room_us_air_quality_index
+              name: Living Room
+              group_by:
+                func: avg
+                duration: 30min
+            - entity: sensor.master_bedroom_us_air_quality_index
+              name: Master Bedroom
+              group_by:
+                func: avg
+                duration: 30min
+            - entity: sensor.guest_room_us_air_quality_index
+              name: Guest Room
+              group_by:
+                func: avg
+                duration: 30min
+            - entity: sensor.downstairs_hallway_us_air_quality_index
+              name: Downstairs
+              group_by:
+                func: avg
+                duration: 30min
+          apex_config:
+            legend:
+              show: false
     view_layout:
       grid-area: right
+      align-self: start
 layout_type: custom:grid-layout
 layout:
   grid-template-columns: 1fr 1fr

--- a/dashboards/components/panels/power.yaml
+++ b/dashboards/components/panels/power.yaml
@@ -1,8 +1,18 @@
 type: custom:layout-card
 cards:
-  - type: custom:layout-card
-    layout_type: vertical
-    cards:
+  - type: custom:mod-card
+    card_mod:
+      style:
+        hui-vertical-stack-card$: |
+          :host {
+            height: auto !important;
+          }
+          #root {
+            gap: 8px;
+          }
+    card:
+      type: vertical-stack
+      cards:
       - type: custom:bar-card
         entities:
           - entity: sensor.server_rack_backup_main_battery
@@ -228,19 +238,31 @@ cards:
             name: Output Current
     view_layout:
       grid-area: left
-  - type: custom:layout-card
-    layout_type: vertical
-    cards:
-      - type: custom:power-flow-card
-        entities:
-          grid: sensor.eagle_200_meter_power_demand
-          solar: sensor.envoy_202317054288_current_power_production
-      - type: energy-usage-graph
-        title: Energy Usage
-      - type: energy-solar-graph
-        title: Solar Production
+      align-self: start
+  - type: custom:mod-card
+    card_mod:
+      style:
+        hui-vertical-stack-card$: |
+          :host {
+            height: auto !important;
+          }
+          #root {
+            gap: 8px;
+          }
+    card:
+      type: vertical-stack
+      cards:
+        - type: custom:power-flow-card
+          entities:
+            grid: sensor.eagle_200_meter_power_demand
+            solar: sensor.envoy_202317054288_current_power_production
+        - type: energy-usage-graph
+          title: Energy Usage
+        - type: energy-solar-graph
+          title: Solar Production
     view_layout:
       grid-area: right
+      align-self: start
 layout_type: custom:grid-layout
 layout:
   grid-template-columns: 1fr 1fr

--- a/dashboards/components/panels/tv_remote_living_room.yaml
+++ b/dashboards/components/panels/tv_remote_living_room.yaml
@@ -1,8 +1,22 @@
 type: custom:layout-card
 cards:
-  - type: custom:layout-card
-    layout_type: vertical
-    cards:
+  - type: custom:mod-card
+    card_mod:
+      style:
+        hui-vertical-stack-card$: |
+          :host {
+            height: auto !important;
+            max-width: 480px;
+            margin-left: auto;
+            margin-right: auto;
+            display: block;
+          }
+          #root {
+            gap: 8px;
+          }
+    card:
+      type: vertical-stack
+      cards:
       - type: grid
         columns: 6
         square: false

--- a/dashboards/components/panels/tv_remote_master_bedroom.yaml
+++ b/dashboards/components/panels/tv_remote_master_bedroom.yaml
@@ -1,8 +1,22 @@
 type: custom:layout-card
 cards:
-  - type: custom:layout-card
-    layout_type: vertical
-    cards:
+  - type: custom:mod-card
+    card_mod:
+      style:
+        hui-vertical-stack-card$: |
+          :host {
+            height: auto !important;
+            max-width: 480px;
+            margin-left: auto;
+            margin-right: auto;
+            display: block;
+          }
+          #root {
+            gap: 8px;
+          }
+    card:
+      type: vertical-stack
+      cards:
       - type: grid
         columns: 6
         square: false

--- a/dashboards/components/panels/upstairs.yaml
+++ b/dashboards/components/panels/upstairs.yaml
@@ -185,8 +185,19 @@ cards:
     square: false
     view_layout:
       grid-area: left-bottom
-  - type: grid
-    cards:
+  - type: custom:mod-card
+    card_mod:
+      style:
+        hui-vertical-stack-card$: |
+          :host {
+            height: auto !important;
+          }
+          #root {
+            gap: 8px;
+          }
+    card:
+      type: vertical-stack
+      cards:
       - type: grid
         cards:
           - type: heading
@@ -344,10 +355,9 @@ cards:
             square: false
         columns: 1
         square: false
-    columns: 1
-    square: false
     view_layout:
       grid-area: right
+      align-self: start
 layout_type: custom:grid-layout
 layout:
   grid-template-columns: 1fr 1fr

--- a/dashboards/components/panels/vacuums.yaml
+++ b/dashboards/components/panels/vacuums.yaml
@@ -1,8 +1,18 @@
 type: custom:layout-card
 cards:
-  - type: custom:layout-card
-    layout_type: vertical
-    cards:
+  - type: custom:mod-card
+    card_mod:
+      style:
+        hui-vertical-stack-card$: |
+          :host {
+            height: auto !important;
+          }
+          #root {
+            gap: 8px;
+          }
+    card:
+      type: vertical-stack
+      cards:
       - type: custom:xiaomi-vacuum-map-card
         title: Upstairs
         map_source:
@@ -335,9 +345,20 @@ cards:
             }
     view_layout:
       grid_area: left
-  - type: custom:layout-card
-    layout_type: vertical
-    cards:
+      align-self: start
+  - type: custom:mod-card
+    card_mod:
+      style:
+        hui-vertical-stack-card$: |
+          :host {
+            height: auto !important;
+          }
+          #root {
+            gap: 8px;
+          }
+    card:
+      type: vertical-stack
+      cards:
       - type: custom:xiaomi-vacuum-map-card
         title: Downstairs
         map_source:
@@ -789,6 +810,7 @@ cards:
             }
     view_layout:
       grid_area: right
+      align-self: start
 layout_type: custom:grid-layout
 layout:
   grid-template-columns: 1fr 1fr


### PR DESCRIPTION
Home Assistant 2026.4 changed how cards inside custom:layout-card with layout_type: vertical (and inner type: grid columns: 1 wrappers spanning multiple page-grid rows) are sized: child cards now stretch to fill the parent column instead of using their natural content height. This caused several panels to render with large vertical gaps, misaligned columns, and cards spreading across the full available height.

Apply a consistent workaround across all affected panels: replace the problematic custom:layout-card layout_type: vertical (and the equivalent type: grid columns: 1 wrapper that spans both page-grid rows on the downstairs/upstairs right columns) with a custom:mod-card wrapping a built-in vertical-stack. The mod-card injects shadow-DOM styles to set height: auto !important on hui-vertical-stack-card's :host (preventing stretch) and gap: 8px on its #root (restoring inter-card spacing that the layout-card vertical layout previously provided).

Per-panel changes:
- home.yaml: both columns rewrapped; align-self: start kept on view_layout to prevent the page-grid columns themselves from stretching to match the tallest neighbor.
- power.yaml: both columns rewrapped (battery/UPS controls left, power-flow/energy graphs right).
- vacuums.yaml: both columns rewrapped (Upstairs map left, Downstairs+Garage maps right).
- downstairs.yaml / upstairs.yaml: only the right column was broken because grid-area: right spans both rows of the page grid; the inner type: grid columns: 1 wrapper distributed its sections across that two-row vertical span instead of stacking tightly. Replaced with the same mod-card + vertical-stack pattern. Left columns use plain type: grid containers and are unaffected.
- tv_remote_living_room.yaml / tv_remote_master_bedroom.yaml: same workaround. Because these panels live in single-column page grids (grid-template-columns: 1fr), additionally constrain the inner vertical-stack-card to max-width: 480px with auto margins via card_mod so the panel matches the original layout-card vertical default width and stays centered horizontally.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style Updates**
  * Improved dashboard panel spacing and alignment across home, power, upstairs, downstairs, vacuums, and TV remote views.
  * Standardized vertical spacing to 8px for consistent visual presentation throughout dashboard panels.
  * Enhanced panel positioning and height handling for better overall layout display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->